### PR TITLE
Add Permissive to puppet-selinux module

### DIFF
--- a/manifests/permissive.pp
+++ b/manifests/permissive.pp
@@ -1,0 +1,41 @@
+# Definition: selinux::permissive
+#
+# Description
+#  This method will set a context to permissive
+#
+# Class create by David Twersky <dmtwersky@gmail.com>
+# Based on selinux::fcontext by Erik M Jacobs<erikmjacobs@gmail.com>
+#  Adds to puppet-selinux by jfryman
+#   https://github.com/jfryman/puppet-selinux
+#  Originally written/sourced from Lance Dillon<>
+#   http://riffraff169.wordpress.com/2012/03/09/add-file-contexts-with-puppet/
+#
+# Parameters:
+#   - $context: A particular context, like "oddjob_mkhomedir_t"
+#
+# Actions:
+#  Runs "semanage permissive -a" with the context you wish to allow
+#
+# Requires:
+#  - SELinux
+#  - policycoreutils-python (for el-based systems)
+#
+# Sample Usage:
+#
+#  selinux::permissive { 'allow-oddjob_mkhomedir_t':
+#    context  => 'oddjob_mkhomedir_t',
+#  }
+#
+define selinux::permissive (
+  $context,
+) {
+
+  include selinux
+
+  exec { "add_${context}":
+    command => "semanage permissive -a ${context}",
+    unless  => "semanage permissive -l|grep ${context}",
+    path    => '/bin:/sbin:/usr/bin:/usr/sbin',
+    require => Class['selinux::package']
+  }
+}


### PR DESCRIPTION
Run 'semanage permissive -a' to set a context to permissive.

I use this to allow oddjob_mkhomedir_t to create home directories upon login if they do not exist.

I am not a puppet developer, so if I missed something, please review it.
